### PR TITLE
travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 python:
     - "2.6"
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ sudo: required
 python:
     - "2.6"
     - "2.7"
-env: PGVERSION=9.1
+addons:
+  postgresql: 9.6
+  apt:
+    packages:
+    - postgresql-9.6-postgis-2.3
 install:
     - bash bin/travis-build.bash
     - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
   postgresql: 9.6
   apt:
     packages:
-    - postgresql-9.6
+    - postgresql-9.6-postgis-2.3
 services:
     - postgresql
 script: sh bin/travis-run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
-language: python
 sudo: required
+group: deprecated-2017Q4
+language: python
 python:
-    - "2.6"
     - "2.7"
+env:
+    - CKANVERSION=2.7
+    - CKANVERSION=2.6
+    - CKANVERSION=2.5
+    - CKANVERSION=2.4
+install:
+    - bash bin/travis-build.bash
 addons:
   postgresql: 9.6
   apt:
     packages:
-    - postgresql-9.6-postgis-2.3
-install:
-    - bash bin/travis-build.bash
-    - pip install coveralls
+    - postgresql-9.6
+services:
+    - postgresql
 script: sh bin/travis-run.sh
+before_install:
+    - pip install codecov
 after_success:
-    - coveralls
+    - codecov

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -5,7 +5,7 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -73,7 +73,7 @@ cd -
 echo "Installing ckanext-ckanext-multilang and its requirements..."
 python setup.py develop
 pip install -r dev-requirements.txt
-paster multilang initdb -c test.ini
+paster multilangdb initdb -c test.ini
 
 echo "Moving test.ini into a subdir..."
 mkdir subdir

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -61,6 +61,15 @@ cd ckan
 paster db init -c test-core.ini
 cd -
 
+echo "Installing ckanext-harvest and its requirements..."
+git clone https://github.com/ckan/ckanext-harvest
+cd ckanext-harvest
+python setup.py develop
+pip install -r pip-requirements.txt --allow-all-external
+paster harvester initdb -c ../ckan/test-core.ini
+cd -
+
+
 echo "Installing ckanext-ckanext-multilang and its requirements..."
 python setup.py develop
 pip install -r dev-requirements.txt

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -73,6 +73,7 @@ cd -
 echo "Installing ckanext-ckanext-multilang and its requirements..."
 python setup.py develop
 pip install -r dev-requirements.txt
+paster multilang initdb -c test.ini
 
 echo "Moving test.ini into a subdir..."
 mkdir subdir

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -54,6 +54,9 @@ echo "Creating the PostgreSQL user and database..."
 
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
+sudo -u postgres psql -d ckan_test -c 'CREATE EXTENSION postgis;'
+sudo -u postgres psql -d ckan_test -c 'ALTER VIEW geometry_columns OWNER TO ckan_default;'
+sudo -u postgres psql -d ckan_test -c 'ALTER TABLE spatial_ref_sys OWNER TO ckan_default;'
 
 
 echo "Install other libraries required..."
@@ -73,6 +76,13 @@ paster harvester initdb -c ../ckan/test-core.ini
 cd -
 
 
+echo "Installing ckanext-spatial and its requirements..."
+git clone https://github.com/ckan/ckanext-spatial
+cd ckanext-spatial
+python setup.py develop
+pip install -r pip-requirements.txt --allow-all-external
+paster spatial initdb -c ../ckan/test-core.ini
+cd -
 
 echo "Moving test.ini into a subdir..."
 mkdir subdir

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -46,6 +46,9 @@ sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 
 sudo service jetty restart
 
+# wait for solr to get up
+sleep 20
+
 echo
 echo "Creating the PostgreSQL user and database..."
 
@@ -70,13 +73,14 @@ paster harvester initdb -c ../ckan/test-core.ini
 cd -
 
 
-echo "Installing ckanext-ckanext-multilang and its requirements..."
-python setup.py develop
-pip install -r dev-requirements.txt
-paster multilangdb initdb -c test.ini
 
 echo "Moving test.ini into a subdir..."
 mkdir subdir
 mv test.ini subdir
+
+echo "Installing ckanext-ckanext-multilang and its requirements..."
+python setup.py develop
+pip install -r dev-requirements.txt
+paster multilangdb initdb -c subdir/test.ini
 
 echo "travis-build.bash is done."

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -1,24 +1,60 @@
 #!/bin/bash
 set -e
+set -x
 
 echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
-sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
+
+# remove faulty mongodb repo, we don't use it anyway
+sudo rm -f /etc/apt/sources.list.d/mongodb-3.2.list
+sudo add-apt-repository --remove 'http://us-central1.gce.archive.ubuntu.com/ubuntu/ main restricted'
+sudo add-apt-repository --remove 'http://us-central1.gce.archive.ubuntu.com/ubuntu/ universe'
+sudo add-apt-repository --remove 'http://us-central1.gce.archive.ubuntu.com/ubuntu/ multiverse'
+sudo add-apt-repository 'http://archive.ubuntu.com/ubuntu/'
+sudo add-apt-repository 'http://archive.ubuntu.com/ubuntu/ universe'
+sudo add-apt-repository 'http://archive.ubuntu.com/ubuntu/ multiverse'
+sudo apt-get -qq --fix-missing update
+sudo apt-get install solr-jetty libcommons-fileupload-java
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-git checkout release-v2.2
+if [ $CKANVERSION == 'master' ]
+then
+    echo "CKAN version: master"
+else
+    CKAN_TAG=$(git tag | grep ^ckan-$CKANVERSION | sort --version-sort | tail -n 1)
+    git checkout $CKAN_TAG
+    echo "CKAN version: ${CKAN_TAG#ckan-}"
+fi
+
+# Unpin CKAN's psycopg2 dependency get an important bugfix
+# https://stackoverflow.com/questions/47044854/error-installing-psycopg2-2-6-2
+sed -i '/psycopg2/c\psycopg2' requirements.txt
+
 python setup.py develop
+
 pip install -r requirements.txt --allow-all-external
 pip install -r dev-requirements.txt --allow-all-external
 cd -
 
+echo
+echo "Setting up Solr..."
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+
+sudo service jetty restart
+
+echo
 echo "Creating the PostgreSQL user and database..."
+
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
+
+
+echo "Install other libraries required..."
+sudo apt-get install python-dev libxml2-dev libxslt1-dev libgeos-c1
 
 echo "Initialising the database..."
 cd ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,3 +1,5 @@
 #!/bin/sh -e
+set -e
+set -x
 
-nosetests --ckan --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.multilang --cover-inclusive --cover-erase --cover-tests
+nosetests --ckan --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.multilang --cover-inclusive --cover-erase --cover-tests ckanext/multilang

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,6 +1,3 @@
 #!/bin/sh -e
 
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
 nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.multilang --cover-inclusive --cover-erase --cover-tests

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.multilang --cover-inclusive --cover-erase --cover-tests
+nosetests --ckan --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.multilang --cover-inclusive --cover-erase --cover-tests

--- a/ckanext/multilang/controllers/package.py
+++ b/ckanext/multilang/controllers/package.py
@@ -17,7 +17,11 @@ log = logging.getLogger(__name__)
 
 render = base.render
 abort = base.abort
-redirect = base.redirect
+try:
+    redirect = base.redirect
+except AttributeError:
+    # ckan 2.7+
+    redirect = helpers.redirect_to
 
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized

--- a/ckanext/multilang/controllers/package.py
+++ b/ckanext/multilang/controllers/package.py
@@ -21,7 +21,7 @@ try:
     redirect = base.redirect
 except AttributeError:
     # ckan 2.7+
-    redirect = helpers.redirect_to
+    redirect = h.redirect_to
 
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized

--- a/ckanext/multilang/controllers/package.py
+++ b/ckanext/multilang/controllers/package.py
@@ -1,36 +1,16 @@
 import logging
-import cgi
-
-import ckan 
-
 import ckan.logic as logic
 import ckan.lib.base as base
-import ckan.plugins as p
-import ckan.lib.maintain as maintain
 import ckanext.multilang.helpers as helpers
 
-from pylons import config
-
-from pylons.i18n.translation import get_lang
-
 from urllib import urlencode
-from paste.deploy.converters import asbool
-from ckan.lib.base import request
-from ckan.lib.base import c, g, h
-from ckan.lib.base import model
-from ckan.lib.base import render
-from ckan.lib.base import _
 
 import ckan.lib.navl.dictization_functions as dict_fns
 
-from ckan.lib.navl.validators import not_empty
-
-from ckan.common import OrderedDict, _, json, request, c, g, response
+from ckan.common import request, c, h, _
 
 from ckan.controllers.package import PackageController
-from ckanext.multilang.model import PackageMultilang, GroupMultilang, ResourceMultilang, TagMultilang
-
-from ckan.controllers.home import CACHE_PARAMETERS
+from ckanext.multilang.model import PackageMultilang, TagMultilang
 
 log = logging.getLogger(__name__)
 
@@ -47,13 +27,16 @@ clean_dict = logic.clean_dict
 tuplize_dict = logic.tuplize_dict
 parse_params = logic.parse_params
 
+
 def _encode_params(params):
     return [(k, v.encode('utf-8') if isinstance(v, basestring) else str(v))
             for k, v in params]
 
+
 def url_with_params(url, params):
     params = _encode_params(params)
     return url + u'?' + urlencode(params)
+
 
 def search_url(params, package_type=None):
     if not package_type or package_type == 'dataset':
@@ -62,9 +45,10 @@ def search_url(params, package_type=None):
         url = h.url_for('{0}_search'.format(package_type))
     return url_with_params(url, params)
 
+
 class MultilangPackageController(PackageController):
 
-    ## Managed localized fields for Package in package_multilang table
+    # Managed localized fields for Package in package_multilang table
     pkg_localized_fields = [
         'title',
         'notes',
@@ -74,7 +58,7 @@ class MultilangPackageController(PackageController):
     ]
 
     """
-       This controller overrides the core PackageController 
+       This controller overrides the core PackageController
        for dataset list view search and dataset details page
     """
 
@@ -246,7 +230,7 @@ class MultilangPackageController(PackageController):
                     log.debug('::::::::::::::: value after %r', result.text)
                     result.save()
 
-                ## Check for missing localized fields in DB
+                # Check for missing localized fields in DB
                 for field in self.pkg_localized_fields:
                     if field not in pkg_processed_field:
                         if c.pkg_dict.get(field):

--- a/ckanext/multilang/controllers/package.py
+++ b/ckanext/multilang/controllers/package.py
@@ -7,7 +7,8 @@ from urllib import urlencode
 
 import ckan.lib.navl.dictization_functions as dict_fns
 
-from ckan.common import request, c, h, _
+from ckan.lib.base import h
+from ckan.common import request, c, _
 
 from ckan.controllers.package import PackageController
 from ckanext.multilang.model import PackageMultilang, TagMultilang


### PR DESCRIPTION
fix #17

This updates travis configuration and build scripts to be usable. Build matrix uses ckan versions from 2.4 to 2.7 and postgresql 9.6 + postgis 2.3

 I've also added small fix for imports in `ckanext.multilang.controllers.package`, which wouldn't work in ckan 2.7.