### PR TITLE
do not update legacy fields in package

### DIFF
--- a/ckanext/multilang/controllers/package.py
+++ b/ckanext/multilang/controllers/package.py
@@ -229,11 +229,15 @@ class MultilangPackageController(PackageController):
             if q_results:
                 pkg_processed_field = []
                 for result in q_results:
-                    pkg_processed_field.append(result.field)
-                    log.debug('::::::::::::::: value before %r', result.text)
-                    result.text = c.pkg_dict.get(result.field)
-                    log.debug('::::::::::::::: value after %r', result.text)
-                    result.save()
+                    # do not update multilang field if original pkg dict doesn't
+                    # have this field anymore. otherwise IntegrityError will raise
+                    # because text will be None
+                    if c.pkg_dict.has_key(result.field):
+                        pkg_processed_field.append(result.field)
+                        log.debug('::::::::::::::: value before %r', result.text)
+                        result.text = c.pkg_dict.get(result.field)
+                        log.debug('::::::::::::::: value after %r', result.text)
+                        result.save()
 
                 # Check for missing localized fields in DB
                 for field in self.pkg_localized_fields:


### PR DESCRIPTION
fix https://github.com/geosolutions-it/ckanext-datitrentinoit/issues/35#issuecomment-426297105

IntegrityError was caused by attempt to update package_multilang table for field that is no more in package. Code will get `None` for that field, and update will yield `NULL` for that field, causing the error. 

Fix will ignore fields that are in multilang and not in package dict.