### PR TITLE
Enable/disable tag localization

### DIFF
--- a/ckanext/multilang/helpers.py
+++ b/ckanext/multilang/helpers.py
@@ -35,7 +35,7 @@ def get_localized_pkg(pkg_dict):
 
         #  MULTILANG - Localizing Tags display names in Facet list
         tags = pkg_dict.get('tags')
-        if tags:
+        if tags and eval(config.get('enable_tag_localization', 'False')):
             for tag in tags:
                 localized_tag = TagMultilang.by_name(tag.get('name'), lang)
 

--- a/ckanext/multilang/helpers.py
+++ b/ckanext/multilang/helpers.py
@@ -6,6 +6,7 @@ import ckan.model as model
 import ckan.plugins as p
 import ckan.lib.search as search
 import ckan.lib.helpers as h
+from ckan.lib.base import config
 
 import ckan.logic as logic
 
@@ -23,6 +24,9 @@ def getLanguage():
         else:
             lang = unicode(lang)
     return lang
+
+def enable_tag_localization():
+    return eval(config.get('enable_tag_localization', 'False'))
 
 def get_localized_pkg(pkg_dict):
     if pkg_dict != '' and 'type' in pkg_dict:

--- a/ckanext/multilang/helpers.py
+++ b/ckanext/multilang/helpers.py
@@ -25,8 +25,10 @@ def getLanguage():
             lang = unicode(lang)
     return lang
 
-def enable_tag_localization():
-    return eval(config.get('enable_tag_localization', 'False'))
+
+def is_tag_loc_enabled():
+    return eval(config.get('multilang.enable_tag_localization', 'False'))
+
 
 def get_localized_pkg(pkg_dict):
     if pkg_dict != '' and 'type' in pkg_dict:
@@ -35,7 +37,7 @@ def get_localized_pkg(pkg_dict):
 
         #  MULTILANG - Localizing Tags display names in Facet list
         tags = pkg_dict.get('tags')
-        if tags and eval(config.get('enable_tag_localization', 'False')):
+        if tags and is_tag_loc_enabled():
             for tag in tags:
                 localized_tag = TagMultilang.by_name(tag.get('name'), lang)
 

--- a/ckanext/multilang/model/package_multilang.py
+++ b/ckanext/multilang/model/package_multilang.py
@@ -284,6 +284,13 @@ class TagMultilang(DomainObject):
         self.text = text
 
     @classmethod
+    def get_all(cls, tag_name, tag_lang=None):
+        query = meta.Session.query(TagMultilang).filter(TagMultilang.tag_name == tag_name)
+        if tag_lang:
+            query = query.filter(TagMultilang.lang == tag_lang)
+        return query
+
+    @classmethod
     def by_name(self, tag_name, tag_lang, autoflush=True):
         query = meta.Session.query(TagMultilang).filter(TagMultilang.tag_name==tag_name, TagMultilang.lang==tag_lang)
         query = query.autoflush(autoflush)
@@ -313,9 +320,9 @@ class TagMultilang(DomainObject):
     def persist(self, tag, lang):
         session = meta.Session
         try:
-            session.add_all([
+            session.add(
                 TagMultilang(tag_id=tag.get('id'), tag_name=tag.get('name'), lang=lang, text=tag.get('text')),
-            ])
+            )
 
             session.commit()
         except Exception, e:
@@ -344,5 +351,6 @@ class TagMultilang(DomainObject):
 
             log.error('Exception occurred while persisting DB objects: %s', e)
             raise
+
 
 meta.mapper(TagMultilang, tag_multilang_table)

--- a/ckanext/multilang/model/package_multilang.py
+++ b/ckanext/multilang/model/package_multilang.py
@@ -326,4 +326,23 @@ class TagMultilang(DomainObject):
             log.error('Exception occurred while persisting DB objects: %s', e)
             raise
 
+    @classmethod
+    def save_tags(cls, *tags):
+        session = meta.Session
+        try:
+            session.add_all([
+                TagMultilang(
+                    tag_id=tag.get(u'id'), tag_name=tag.get(u'name'), lang=tag.get(u'lang'), text=tag.get(u'text'))
+                for tag in tags
+            ])
+
+            session.commit()
+        except Exception, e:
+            # on rollback, the same closure of state
+            # as that of commit proceeds.
+            session.rollback()
+
+            log.error('Exception occurred while persisting DB objects: %s', e)
+            raise
+
 meta.mapper(TagMultilang, tag_multilang_table)

--- a/ckanext/multilang/plugin.py
+++ b/ckanext/multilang/plugin.py
@@ -40,7 +40,7 @@ class MultilangPlugin(plugins.SingletonPlugin):
             'get_localized_pkg': helpers.get_localized_pkg,
             'get_localized_group': helpers.get_localized_group,
             'get_localized_resource': helpers.get_localized_resource,
-            'enable_tag_localization': helpers.enable_tag_localization
+            'is_tag_loc_enabled': helpers.is_tag_loc_enabled,
         }
 
     def get_actions(self):
@@ -86,7 +86,7 @@ class MultilangPlugin(plugins.SingletonPlugin):
                 #  MULTILANG - Localizing Datasets names and descriptions in search list
                 #  MULTILANG - Localizing Tags display names in Facet list
                 tags = odict.get('tags')
-                if tags and eval(config.get('enable_tag_localization', 'False')):
+                if tags and helpers.is_tag_loc_enabled():
                     for tag in tags:
                         localized_tag = TagMultilang.by_tag_id(tag.get('id'), lang)
 

--- a/ckanext/multilang/plugin.py
+++ b/ckanext/multilang/plugin.py
@@ -39,7 +39,8 @@ class MultilangPlugin(plugins.SingletonPlugin):
         return {
             'get_localized_pkg': helpers.get_localized_pkg,
             'get_localized_group': helpers.get_localized_group,
-            'get_localized_resource': helpers.get_localized_resource
+            'get_localized_resource': helpers.get_localized_resource,
+            'enable_tag_localization': helpers.enable_tag_localization
         }
 
     def get_actions(self):
@@ -85,7 +86,7 @@ class MultilangPlugin(plugins.SingletonPlugin):
                 #  MULTILANG - Localizing Datasets names and descriptions in search list
                 #  MULTILANG - Localizing Tags display names in Facet list
                 tags = odict.get('tags')
-                if tags:
+                if tags and eval(config.get('enable_tag_localization', 'False')):
                     for tag in tags:
                         localized_tag = TagMultilang.by_tag_id(tag.get('id'), lang)
 

--- a/ckanext/multilang/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/multilang/templates/package/snippets/package_basic_fields.html
@@ -5,6 +5,8 @@
 {% block package_basic_fields_tags %} 
   {{ super() }}
 
+{% set enable_tag_localization = h.enable_tag_localization() %}
+{% if enable_tag_localization %}
   <div data-module="custom-fields">
     {% for tag in data.tags %}
       {% set prefix = 'extra_tag__%d__' % loop.index0 %}
@@ -15,7 +17,7 @@
         values=(tag.name, tag.display_name, False),
         error=errors[prefix ~ 'key'] or errors[prefix ~ 'value'],
         attrs={'readonly': 'true'}
-      ) }}  
+      ) }}
     {% endfor %}
 
     {# Add a max of 1 empty columns #}
@@ -35,6 +37,7 @@
       ) }}
     {% endfor %}
   </div>
+{% endif %}
 {% endblock %}
 
 {% block package_basic_fields_org %}

--- a/ckanext/multilang/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/multilang/templates/package/snippets/package_basic_fields.html
@@ -5,8 +5,7 @@
 {% block package_basic_fields_tags %} 
   {{ super() }}
 
-{% set enable_tag_localization = h.enable_tag_localization() %}
-{% if enable_tag_localization %}
+{% if h.is_tag_loc_enabled() %}
   <div data-module="custom-fields">
     {% for tag in data.tags %}
       {% set prefix = 'extra_tag__%d__' % loop.index0 %}


### PR DESCRIPTION
### what does the PR do?
- Makes tags localizations configurable by letting a user flip it to true or false using `enable_tag_localization` configuration key in production.ini

### changes made
- Added an enable_tag_localization helper function that provides the boolean value of `enable_tag_localization` settings key to templates
- Disabled tags localization interface from being shown in templates based on `enable_tag_localization` settings key
- Disabled tags localization in `MultilangPlugin. get_actions`